### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,23 @@ This repository allows you to quickly install a Neos CMS environment as a Ddev p
 
 ## Installation
 
-* `ddev get haase-fabian/ddev-neos`
-* `ddev restart`
+For DDEV v1.23.5 or above run
+
+```bash
+ddev add-on get haase-fabian/ddev-neos
+```
+
+For earlier versions of DDEV run
+
+```bash
+ddev get haase-fabian/ddev-neos
+```
+
+Then restart your project
+
+```bash
+ddev restart
+```
 
 ## Explanation
 


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.